### PR TITLE
feat: Improve overall UI/UX for frontend

### DIFF
--- a/apps/ShaTi-frontend/src/components/Header.vue
+++ b/apps/ShaTi-frontend/src/components/Header.vue
@@ -1,10 +1,10 @@
 <template>
   <header class="p-4 border-b border-primary-300">
     <div class="flex justify-between items-center max-w-[1440px] mx-auto">
-      <div class="flex items-center gap-2">
+      <NuxtLink to="/" class="flex items-center gap-2">
         <img src="~/assets/img/shati.svg" alt="ShaTi Logo" class="h-10 w-10" />
         <span class="text-xl font-bold">ShaTi</span>
-      </div>
+      </NuxtLink>
       <nav>
         <ul class="flex items-center space-x-4">
           <li>

--- a/apps/ShaTi-frontend/src/components/Home.vue
+++ b/apps/ShaTi-frontend/src/components/Home.vue
@@ -3,7 +3,7 @@
     <div class="z-10">
       <h1 class="text-4xl sm:text-5xl md:text-6xl font-bold leading-tight mb-4">タイムキーパーは<br>シャチに任せよう。</h1>
       <p class="text-base sm:text-lg mb-8">ShaTi /ˈʃɑːtʃi/ はオンラインでタイマーを共有できるツールです。<br>タイムキーパーだけがタイマーを監視する必要はもうありません。</p>
-      <UButton color="secondary" variant="solid" class="font-bold flex items-center">
+      <UButton to="/timer" color="secondary" variant="solid" class="font-bold inline-flex items-center">
         <span>使ってみる</span>
         <img src="~/assets/img/arrow.svg" alt="arrow" class="ml-2" />
       </UButton>

--- a/apps/ShaTi-frontend/src/layouts/default.vue
+++ b/apps/ShaTi-frontend/src/layouts/default.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <Header />
-      <main class="max-w-1440px mx-auto">
+      <main class="max-w-[1440px] mx-auto min-h-[calc(100vh-298px)]">
         <NuxtPage />
       </main>
     <Footer />

--- a/apps/ShaTi-frontend/src/layouts/default.vue
+++ b/apps/ShaTi-frontend/src/layouts/default.vue
@@ -1,9 +1,9 @@
 <template>
-  <div>
+  <div class="flex flex-col min-h-screen">
     <Header />
-      <main class="max-w-[1440px] mx-auto min-h-[calc(100vh-298px)]">
-        <NuxtPage />
-      </main>
+    <main class="flex-1 max-w-[1440px] mx-auto w-full">
+      <NuxtPage />
+    </main>
     <Footer />
   </div>
 </template>


### PR DESCRIPTION
- Header: Made the ShaTi logo and text clickable, navigating to the homepage (/).
- Landing Page: Configured the "Try it" button to navigate to the timer list page (/timer).
- Layout: Adjusted the main content area's minimum height to ensure the footer remains at the bottom of the screen, even with minimal content.
- Landing Page: Fixed the "Try it" button's width by applying `inline-flex` to prevent it from stretching horizontally.
