### PR TITLE
feat(lint): Configure ESLint and fix linting issues

### DIFF
--- a/apps/ShaTi-backend/project.json
+++ b/apps/ShaTi-backend/project.json
@@ -14,6 +14,14 @@
         "command": "yarn build",
         "cwd": "apps/ShaTi-backend"
       }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "options": {
+        "lintFilePatterns": [
+          "apps/ShaTi-backend/**/*.ts"
+        ]
+      }
     }
   }
 }

--- a/apps/ShaTi-backend/src/index.ts
+++ b/apps/ShaTi-backend/src/index.ts
@@ -54,25 +54,25 @@ app.get('/timer/:id', durableObjectMiddleware, cors(), async (c) => {
   return c.json(timer);
 });
 
-app.post('/timer/:id/start', durableObjectMiddleware, cors(), async (c, next) => {
+app.post('/timer/:id/start', durableObjectMiddleware, cors(), async (c) => {
   const timerId = await c.req.param('id');
 
   return c.json(await c.var.stub.startTimer(timerId))
 })
 
-app.post('/timer/:id/resume', durableObjectMiddleware, cors(), async (c, next) => {
+app.post('/timer/:id/resume', durableObjectMiddleware, cors(), async (c) => {
   const timerId = await c.req.param('id');
 
   return c.json(await c.var.stub.resumeTimer(timerId));
 });
 
-app.post('/timer/:id/stop', durableObjectMiddleware, cors(), async (c, next) => {
+app.post('/timer/:id/stop', durableObjectMiddleware, cors(), async (c) => {
   const timerId = await c.req.param('id');
 
   return c.json(await c.var.stub.stopTimer(timerId))
 });
 
-app.post('/timer/:id/pause', durableObjectMiddleware, cors(), async (c, next) => {
+app.post('/timer/:id/pause', durableObjectMiddleware, cors(), async (c) => {
   const timerId = await c.req.param('id');
 
   return c.json(await c.var.stub.pauseTimer(timerId))

--- a/apps/ShaTi-frontend/nuxt.config.ts
+++ b/apps/ShaTi-frontend/nuxt.config.ts
@@ -1,5 +1,5 @@
 import { URL, fileURLToPath } from "node:url";
-import ui from '@nuxt/ui/vite';
+
 
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({

--- a/apps/ShaTi-frontend/project.json
+++ b/apps/ShaTi-frontend/project.json
@@ -14,6 +14,15 @@
         "command": "yarn build",
         "cwd": "apps/ShaTi-frontend"
       }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "options": {
+        "lintFilePatterns": [
+          "apps/ShaTi-frontend/**/*.ts",
+          "apps/ShaTi-frontend/**/*.vue"
+        ]
+      }
     }
   }
 }

--- a/apps/ShaTi-frontend/src/store/useTimerStore.ts
+++ b/apps/ShaTi-frontend/src/store/useTimerStore.ts
@@ -80,7 +80,7 @@ export const useTimerStore = defineStore('timer', () => {
 
     socket.value.onmessage = (event) => {
       const data = JSON.parse(event.data.toString());
-      if (data.hasOwnProperty('maintain')) {
+      if (Object.prototype.hasOwnProperty.call(data, 'maintain')) {
         console.log('WebSocket maintain :)');
       } else timer.value = data;
     };

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,7 +5,14 @@ module.exports = [
   ...nx.configs['flat/typescript'],
   ...nx.configs['flat/javascript'],
   {
-    ignores: ['**/dist'],
+    ignores: [
+      '**/dist',
+      'apps/ShaTi-frontend/.nuxt/**',
+      'apps/ShaTi-frontend/.output/**',
+      'apps/ShaTi-frontend/backend/**',
+      'apps/ShaTi-frontend/dev/**',
+      'apps/ShaTi-backend/.wrangler/**',
+    ],
   },
   {
     files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
@@ -14,7 +21,7 @@ module.exports = [
         'error',
         {
           enforceBuildableLibDependency: true,
-          allow: ['^.*/eslint(\\.base)?\\.config\\.[cm]?js$'],
+          allow: ['^.*/eslint(\.base)?\.config\.[cm]?js$'],
           depConstraints: [
             {
               sourceTag: '*',

--- a/libs/types/project.json
+++ b/libs/types/project.json
@@ -7,19 +7,33 @@
   "targets": {
     "build": {
       "executor": "@nx/js:tsc",
-      "outputs": ["{options.outputPath}"],
+      "outputs": [
+        "{options.outputPath}"
+      ],
       "options": {
         "outputPath": "dist/libs/types",
         "main": "libs/types/src/index.ts",
         "tsConfig": "libs/types/tsconfig.lib.json",
-        "assets": ["libs/types/*.md"]
+        "assets": [
+          "libs/types/*.md"
+        ]
       }
     },
     "test": {
       "executor": "@nx/vite:test",
-      "outputs": ["{options.reportsDirectory}"],
+      "outputs": [
+        "{options.reportsDirectory}"
+      ],
       "options": {
         "reportsDirectory": "../../coverage/libs/types"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "options": {
+        "lintFilePatterns": [
+          "libs/types/**/*.ts"
+        ]
       }
     }
   }

--- a/libs/utils/project.json
+++ b/libs/utils/project.json
@@ -7,19 +7,33 @@
   "targets": {
     "build": {
       "executor": "@nx/js:tsc",
-      "outputs": ["{options.outputPath}"],
+      "outputs": [
+        "{options.outputPath}"
+      ],
       "options": {
         "outputPath": "dist/libs/utils",
         "main": "libs/utils/src/index.ts",
         "tsConfig": "libs/utils/tsconfig.lib.json",
-        "assets": ["libs/utils/*.md"]
+        "assets": [
+          "libs/utils/*.md"
+        ]
       }
     },
     "test": {
       "executor": "@nx/vite:test",
-      "outputs": ["{options.reportsDirectory}"],
+      "outputs": [
+        "{options.reportsDirectory}"
+      ],
       "options": {
         "reportsDirectory": "../../coverage/libs/utils"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "options": {
+        "lintFilePatterns": [
+          "libs/utils/**/*.ts"
+        ]
       }
     }
   }

--- a/nx.json
+++ b/nx.json
@@ -2,15 +2,27 @@
   "installation": {
     "version": "20.2.2"
   },
+  "workspaceLayout": {
+    "appsDir": "apps",
+    "libsDir": "libs"
+  },
   "targetDefaults": {
     "@nx/js:tsc": {
       "cache": true,
-      "dependsOn": ["^build"],
-      "inputs": ["default", "^default"]
+      "dependsOn": [
+        "^build"
+      ],
+      "inputs": [
+        "default",
+        "^default"
+      ]
     },
     "@nx/vite:test": {
       "cache": true,
-      "inputs": ["default", "^default"]
+      "inputs": [
+        "default",
+        "^default"
+      ]
     }
   },
   "plugins": [


### PR DESCRIPTION
- Add `lint` targets to `project.json` files for frontend, backend, types, and utils projects using `@nx/eslint:lint` executor.
- Update `eslint.config.js` to ignore generated files and fix regex in `allow` rule.
- Fix `hasOwnProperty` usage in `apps/ShaTi-frontend/src/store/useTimerStore.ts`.
- Remove unused `ui` import in `apps/ShaTi-frontend/nuxt.config.ts`.
- Remove unused `next` parameters in `apps/ShaTi-backend/src/index.ts`.
- Refactor `apps/ShaTi-backend/src/timer.ts` to remove unused parameters and replace non-null assertions with optional chaining and proper initialization.
- Add `workspaceLayout` to `nx.json` for proper project graph processing.