### PR TITLE
fix: Timer synchronization issue across multiple devices

### DIFF
--- a/apps/ShaTi-backend/src/timer.ts
+++ b/apps/ShaTi-backend/src/timer.ts
@@ -149,6 +149,7 @@ export class TimerDurableObjects extends DurableObject {
       (cf_timer.duration?.seconds || 0);
     cf_timer.isRunning = true;
     cf_timer.isPausing = false;
+    cf_timer.remainDuration = undefined;
     await this.ctx.storage.put(id, cf_timer);
 
     await this.multicast(id, JSON.stringify(cf_timer));

--- a/apps/ShaTi-frontend/src/components/timer/page/index.vue
+++ b/apps/ShaTi-frontend/src/components/timer/page/index.vue
@@ -16,11 +16,15 @@
 <script setup lang="ts">
 import type { Timer } from '@shati/types';
 import { ref, computed, watch, onMounted, onUnmounted, type PropType } from 'vue'
+import { storeToRefs } from 'pinia';
 
 const alarmUrl = '/audio/alarm.mp3'
 const preAlarmUrl = '/audio/pre-alarm.mp3'
 
 const emits = defineEmits(['onStart', 'onStop', 'onPause', 'onResume'])
+
+const timerStore = useTimerStore();
+const { timeOffset } = storeToRefs(timerStore);
 
 const now = ref(0)
 const alarmSound = ref<HTMLAudioElement | undefined>(undefined)
@@ -65,7 +69,7 @@ const triggerPreAlarm = () => {
 
 const tick = () => {
   const prevNow = now.value; // 前回のnowの値を保存
-  now.value = Math.floor(Date.now() / 1000);
+  now.value = Math.floor(Date.now() / 1000) + timeOffset.value;
 
   // タイマーが実行中で一時停止中でない場合のみアラームをチェック
   if (timer.isRunning && !timer.isPausing) {


### PR DESCRIPTION
This commit addresses the issue where the timer stops or behaves inconsistently when operated from multiple devices.

The following changes were made:
- Frontend (`apps/ShaTi-frontend/src/components/timer/page/index.vue`):
  - Implemented server-client time synchronization by utilizing `timeOffset` from `useTimerStore`. This ensures that the timer display accurately reflects the server-side state, mitigating discrepancies caused by local clock drift.
- Backend (`apps/ShaTi-backend/src/timer.ts`):
  - Modified the `startTimer` method to explicitly reset `remainDuration` to `undefined`. This guarantees that the timer always begins from its initial duration, preventing residual values from previous pauses from affecting new starts.

These changes ensure consistent timer behavior across all connected devices.

Closes #18