### PR TITLE
Potential fix for code scanning alert no. 12: Server-side request forgery

### DIFF
--- a/apps/ShaTi-frontend/app/stores/useTimerStore.ts
+++ b/apps/ShaTi-frontend/app/stores/useTimerStore.ts
@@ -8,6 +8,11 @@ type TimeResponse = {
 
 export const useTimerStore = defineStore('timer', () => {
   const config = useRuntimeConfig();
+
+  // Accepts only alphanumeric IDs, dashes, and underscores (adjust as needed)
+  function isValidTimerId(id: string): boolean {
+    return typeof id === 'string' && /^[a-zA-Z0-9_-]+$/.test(id);
+  }
   const timer = ref<Timer>({
     id: '',
     name: '',
@@ -100,7 +105,7 @@ export const useTimerStore = defineStore('timer', () => {
   }
 
   async function start() {
-    if (!timer.value.id) {
+    if (!timer.value.id || !isValidTimerId(timer.value.id)) {
       return;
     }
     await fetch(`${config.public.apiBase}/timer/${timer.value.id}/start`, {
@@ -109,7 +114,7 @@ export const useTimerStore = defineStore('timer', () => {
   }
 
   async function stop() {
-    if (!timer.value.id) {
+    if (!timer.value.id || !isValidTimerId(timer.value.id)) {
       return;
     }
     await fetch(`${config.public.apiBase}/timer/${timer.value.id}/stop`, {
@@ -118,7 +123,7 @@ export const useTimerStore = defineStore('timer', () => {
   }
 
   async function pause() {
-    if (!timer.value.id) {
+    if (!timer.value.id || !isValidTimerId(timer.value.id)) {
       return;
     }
     await fetch(`${config.public.apiBase}/timer/${timer.value.id}/pause`, {
@@ -127,7 +132,7 @@ export const useTimerStore = defineStore('timer', () => {
   }
 
   async function resume() {
-    if (!timer.value.id) {
+    if (!timer.value.id || !isValidTimerId(timer.value.id)) {
       return;
     }
     await fetch(`${config.public.apiBase}/timer/${timer.value.id}/resume`, {


### PR DESCRIPTION
Potential fix for [https://github.com/toreis-up/shati/security/code-scanning/12](https://github.com/toreis-up/shati/security/code-scanning/12)

To fix this issue, we need to ensure that `timer.value.id` is validated before it is used to construct URLs for outgoing HTTP requests. The best approach is to validate that `timer.value.id` matches the expected format for timer IDs (e.g., a UUID or a specific alphanumeric pattern) before using it in the `resume`, `pause`, `start`, and `stop` functions. This can be done by introducing a validation function (e.g., `isValidTimerId`) and checking the ID before making the request. If the ID is invalid, the function should return early or throw an error, preventing the potentially dangerous request.

The changes should be made in `apps/ShaTi-frontend/app/stores/useTimerStore.ts`:
- Add a helper function `isValidTimerId` that checks the format of the timer ID.
- Use this function to validate `timer.value.id` in the `resume`, `pause`, `start`, and `stop` functions before making the fetch request.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
